### PR TITLE
Respond to casual issue mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ config.handlers.jira.username = 'your_jira_username'
 config.handlers.jira.password = 'a_password'
 config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 config.handlers.jira.context  = '' # If your instance is in a /subdirectory, put that here
+config.handlers.jira.issue_pattern = 'FOO-\d+' # (optional) it will make lita comment each time an issue is mentioned
 ```
 
 ## Usage

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -10,6 +10,7 @@ module Lita
       config :password, required: true
       config :site, required: true
       config :context, required: true
+      config :issue_pattern
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -78,6 +79,13 @@ module Lita
         return response.reply(t('error.request')) unless issue
         response.reply(t('issue.created', key: issue.key))
       end
+
+      Lita.register_hook(:before_run, -> (payload) do
+        ConfigurationBuilder.load_user_config(payload[:config_path])
+        if issue_pattern = Lita.config.handlers.jira.issue_pattern
+          route Regexp.new("(?<issue>#{issue_pattern})"), :summary
+        end
+      end)
     end
 
     Lita.register_handler(Jira)


### PR DESCRIPTION
Added a configuration option to make the bot listen to any mentions of the JIRA issues and respond with summary.