### PR TITLE
adding myissues feature and initial support for Issue#jql searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ todo <project> "<subject>" ["<summary>"] - Creates an issue in <project> with <s
 jira <issue>                             - Shows a short summary <issue>
 jira details <issue>                     - Shows all details about <issue>
 jira comment on <issue> <comment text>   - Adds <comment text> to <issue>
+jira myissues                            - Displays a list of issues assigned to identified user
 ```
 
 ### Misc

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,6 +28,9 @@ en:
           todo:
             syntax: todo <project> "<subject>" ["<summary>"]
             desc: Creates an issue in <project> with <subject> and optionally <summary>
+          myissues:
+            syntax: jira myissues
+            desc: If identified, will display a list of issues currently assigned to you
         identify:
           stored: "You have been identified as %{email} to JIRA"
           deleted: You have been de-identified from JIRA
@@ -38,3 +41,6 @@ en:
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"
+        myissues:
+          empty: "You do not have any assigned issues. Great job!"
+          info: "Here are issues currently assigned to you:"


### PR DESCRIPTION
This adds a new feature/route called myissues. It allows a user, if identified, to retrieve a list of assigned issues to them from JIRA that are 'active'. I take active to mean everything but tickets that are in the Closed status of a workflow.

It also adds initial support for Issue#jql from https://github.com/sumoheavy/jira-ruby/blob/master/lib/jira/resource/issue.rb#L47

This could eventually be leveraged to support more generic JIRA searching, but that seemed to be biting off too much for a single PR.