### PR TITLE
[DEV-281] Add ambient issue detection and one-line formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ FileName:
     - lib/lita-jira.rb
 
 LineLength:
-  Max: 130
+  Max: 190

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 config.handlers.jira.context  = '' # If your instance is in a /subdirectory, put that here
 ```
 
+### Optional attributes
+* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+```
+config.handlers.jira.ambient = true
+```
+
 ## Usage
 
 ### Shortcuts

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 
 ### Optional attributes
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
-* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
-* `ignore` (array) - Prevent JIRA issue lookups from certain users with this parameter. Default: `[]`
-* `rooms` (array) - Specify a list of rooms to which responses to detected ambient JIRA issues should be limited. By default, the bot will respond to all rooms.
+* `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+* `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Default: `[]`
+* `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
 
 ``` ruby
 config.handlers.jira.context = '/myjira'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gem "lita-jira"
 
 Add the following variables to your lita config file:
 
-```
+``` ruby
 config.handlers.jira.username = 'your_jira_username'
 config.handlers.jira.password = 'a_password'
 config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
@@ -31,10 +31,15 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
-```
+* `ignore` (array) - Prevent JIRA issue lookups from certain users with this parameter. Default: `[]`
+* `rooms` (array) - Specify a list of rooms to which responses to detected ambient JIRA issues should be limited. By default, the bot will respond to all rooms.
+
+``` ruby
 config.handlers.jira.context = '/myjira'
 config.handlers.jira.ambient = true
 config.handlers.jira.format = 'one-line'
+config.handlers.jira.ignore = ['Jira', 'Github']
+config.handlers.jira.rooms = ['devtools', 'engineering']
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,13 +25,16 @@ Add the following variables to your lita config file:
 config.handlers.jira.username = 'your_jira_username'
 config.handlers.jira.password = 'a_password'
 config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
-config.handlers.jira.context  = '' # If your instance is in a /subdirectory, put that here
 ```
 
 ### Optional attributes
+* `context` (string) - If your instance is in a /subdirectory, put that here. Default: `''`
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
+* `format` (string) - You can select a compact one line issue summary by setting this parameter to `one-line`. Default: `verbose`
 ```
+config.handlers.jira.context = '/myjira'
 config.handlers.jira.ambient = true
+config.handlers.jira.format = 'one-line'
 ```
 
 ## Usage

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -23,18 +23,13 @@ module JiraHelper
         log.error('JIRA HTTPError')
         nil
     end
-
-    def format_issue(issue)
+def format_issue(issue)
       t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
         status: issue.status.name,
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
-        fixVersion: optional_issue_property('none') do
-          v = issue.fixVersions
-          raise if v == []
-          v
-        end,
+        fixVersion: optional_issue_property('none') { issue.fixVersions.first['name'] },
         priority: optional_issue_property('none') { issue.priority.name },
         url: format_issue_link(issue.key))
     end

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -25,12 +25,18 @@ module JiraHelper
     end
 
     def format_issue(issue)
-      t('issue.details',
+      t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
+        status: issue.status.name,
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
+        fixVersion: optional_issue_property('none') do
+          v = issue.fixVersions
+          raise if v.empty?
+          v
+        end,
         priority: optional_issue_property('none') { issue.priority.name },
-        status: issue.status.name)
+        url: format_issue_link(issue.key))
     end
 
     # Enumerate issues returned from JQL query and format for response
@@ -40,6 +46,10 @@ module JiraHelper
     def format_issues(issues)
       results = [t('myissues.info')]
       results.concat(issues.map { |issue| format_issue(issue) })
+    end
+
+    def format_issue_link(key)
+      "#{config.site}/browse/#{key}"
     end
 
     def create_issue(project, subject, summary)

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,11 +2,11 @@
 module JiraHelper
   # Issues
   module Issue
-    def fetch_issue(key, expected=true)
+    def fetch_issue(key, expected = true)
       client.Issue.find(key)
-      rescue
-        log.error('JIRA HTTPError') if expected
-        nil
+    rescue
+      log.error('JIRA HTTPError') if expected
+      nil
     end
 
     # Leverage the jira-ruby Issue.jql search feature
@@ -19,11 +19,14 @@ module JiraHelper
 
     def fetch_project(key)
       client.Project.find(key)
-      rescue
-        log.error('JIRA HTTPError')
-        nil
+    rescue
+      log.error('JIRA HTTPError')
+      nil
     end
-def format_issue(issue)
+
+    # NOTE: Not breaking this function out just yet.
+    # rubocop:disable Metrics/AbcSize
+    def format_issue(issue)
       t(config.format == 'one-line' ? 'issue.oneline' : 'issue.details',
         key: issue.key,
         summary: issue.summary,
@@ -33,6 +36,7 @@ def format_issue(issue)
         priority: optional_issue_property('none') { issue.priority.name },
         url: format_issue_link(issue.key))
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Enumerate issues returned from JQL query and format for response
     #

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -49,7 +49,7 @@ module JiraHelper
     end
 
     def format_issue_link(key)
-      "#{config.site}/browse/#{key}"
+      "#{config.site}#{config.context}/browse/#{key}"
     end
 
     def create_issue(project, subject, summary)

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -2,10 +2,10 @@
 module JiraHelper
   # Issues
   module Issue
-    def fetch_issue(key)
+    def fetch_issue(key, expected=true)
       client.Issue.find(key)
       rescue
-        log.error('JIRA HTTPError')
+        log.error('JIRA HTTPError') if expected
         nil
     end
 

--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -32,7 +32,7 @@ module JiraHelper
         assigned: optional_issue_property('unassigned') { issue.assignee.displayName },
         fixVersion: optional_issue_property('none') do
           v = issue.fixVersions
-          raise if v.empty?
+          raise if v == []
           v
         end,
         priority: optional_issue_property('none') { issue.priority.name },

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -12,6 +12,8 @@ module Lita
       config :context, required: false, type: String, default: ''
       config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :format, required: false, type: String, default: 'verbose'
+      config :ignore, required: false, type: Array, default: []
+      config :rooms, required: false, type: Array
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -112,6 +114,8 @@ module Lita
       end
 
       def ambient(response)
+        return if config.ignore.include?(response.user.name)
+        return if config.rooms && !config.rooms.include?(response.message.source.room)
         if config.ambient && !response.message.command?
           issue = fetch_issue(response.match_data['issue'], expected=false)
           response.reply(format_issue(issue)) if issue

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -10,8 +10,8 @@ module Lita
       config :password, required: true, type: String
       config :site, required: true, type: String
       config :context, required: false, type: String, default: ''
-      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :format, required: false, type: String, default: 'verbose'
+      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :ignore, required: false, type: Array, default: []
       config :rooms, required: false, type: Array
 

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -114,13 +114,15 @@ module Lita
       end
 
       def ambient(response)
-        return if config.ignore.include?(response.user.name)
-        return if config.rooms && !config.rooms.include?(response.message.source.room)
-        return if response.message.command?
-        return unless config.ambient
-
+        return if invalid_ambient(response)
         issue = fetch_issue(response.match_data['issue'], false)
         response.reply(format_issue(issue)) if issue
+      end
+
+      private
+
+      def invalid_ambient(response)
+        response.message.command? || !config.ambient || config.ignore.include?(response.user.name) || (config.rooms && !config.rooms.include?(response.message.source.room))
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -6,11 +6,12 @@ module Lita
     class Jira < Handler
       namespace 'Jira'
 
-      config :username, required: true
-      config :password, required: true
-      config :site, required: true
-      config :context, required: true
-      config :ambient, types: [TrueClass, FalseClass], default: false
+      config :username, required: true, type: String
+      config :password, required: true, type: String
+      config :site, required: true, type: String
+      config :context, required: false, type: String, default: ''
+      config :ambient, required: false, types: [TrueClass, FalseClass], default: false
+      config :format, required: false, type: String, default: 'verbose'
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc
@@ -113,7 +114,7 @@ module Lita
       def ambient(response)
         if config.ambient && !response.message.command?
           issue = fetch_issue(response.match_data['issue'], expected=false)
-          response.reply(t('issue.summary', key: issue.key, summary: issue.summary)) if issue
+          response.reply(format_issue(issue)) if issue
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -116,10 +116,11 @@ module Lita
       def ambient(response)
         return if config.ignore.include?(response.user.name)
         return if config.rooms && !config.rooms.include?(response.message.source.room)
-        if config.ambient && !response.message.command?
-          issue = fetch_issue(response.match_data['issue'], expected=false)
-          response.reply(format_issue(issue)) if issue
-        end
+        return if response.message.command?
+        return unless config.ambient
+
+        issue = fetch_issue(response.match_data['issue'], false)
+        response.reply(format_issue(issue)) if issue
       end
       # rubocop:enable Metrics/AbcSize
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,7 +37,8 @@ en:
           email: "You are identified with JIRA as %{email}"
         issue:
           created: "Issue %{key} created"
-          details: "%{key}: %{summary}, assigned to: %{assigned}, priority: %{priority}, status: %{status}"
+          details: "[%{key}] %{summary}\nStatus: %{status}, assigned to: %{assigned}, fixVersion: %{fixVersion}, priority: %{priority}\n%{url}"
+          oneline: "%{url} - %{status}, %{assigned} - %{summary}"
           summary: "%{key}: %{summary}"
         comment:
           added: "Comment added to %{issue}"

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -10,7 +10,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
                     assignee: double(displayName: 'A Person'),
                     priority: double(name: 'P0'),
                     status: double(name: 'In Progress'),
-                    fixVersions: [{'name' => 'Sprint 2'}],
+                    fixVersions: [{ 'name' => 'Sprint 2' }],
                     key: 'XYZ-987')
     allow(result).to receive('save') { true }
     allow(result).to receive('fetch') { true }
@@ -34,7 +34,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
                      assignee: double(displayName: 'A Person'),
                      priority: double(name: 'P0'),
                      status: double(name: 'In Progress'),
-                     fixVersions: [{'name' => 'Sprint 2'}],
+                     fixVersions: [{ 'name' => 'Sprint 2' }],
                      key: 'XYZ-987'),
               double(summary: 'Some summary text 2',
                      assignee: double(displayName: 'A Person 2'),
@@ -179,7 +179,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
     end
   end
 
-  describe "#ambient" do
+  describe '#ambient' do
     it 'does not show details for a detected issue by default' do
     end
 
@@ -239,7 +239,6 @@ describe Lita::Handlers::Jira, lita_handler: true do
         end
       end
     end
-
   end
 
   describe '#myissues' do

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -128,6 +128,14 @@ describe Lita::Handlers::Jira, lita_handler: true do
       expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: unassigned, fixVersion: none, priority: none\nhttp://jira.local/browse/XYZ-987")
     end
 
+    it 'displays the correct URL when config.context is set' do
+      registry.config.handlers.jira.context = '/myjira'
+      grab_request(valid_client)
+      send_command('jira details XYZ-987')
+      expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/myjira/browse/XYZ-987")
+      registry.config.handlers.jira.context = ''
+    end
+
     it 'warns the user when the issue is not valid' do
       grab_request(failed_find_issue)
       send_command('jira details XYZ-987')
@@ -169,6 +177,69 @@ describe Lita::Handlers::Jira, lita_handler: true do
       send_command('todo ABC "Some summary text"')
       expect(replies.last).to eq('Error fetching JIRA issue')
     end
+  end
+
+  describe "#ambient" do
+    it 'does not show details for a detected issue by default' do
+    end
+
+    context 'when enabled in config' do
+      before(:each) do
+        registry.config.handlers.jira.ambient = true
+        grab_request(valid_client)
+      end
+
+      it 'shows details for a detected issue in a message' do
+        send_message('foo XYZ-987 bar')
+        expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+      end
+
+      it 'does not show details for a detected issue in a command' do
+        send_command('foo XYZ-987 bar')
+        expect(replies.size).to eq(0)
+      end
+
+      context 'and an ignore list is defined' do
+        before(:each) do
+          @user1 = Lita::User.create(1, name: 'User1')
+          @user2 = Lita::User.create(2, name: 'User2')
+          registry.config.handlers.jira.ignore = ['User2']
+        end
+
+        it 'shows details for a detected issue sent by a user absent from the list' do
+          send_message('foo XYZ-987 bar', as: @user1)
+          expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        end
+
+        it 'does not show details for a detected issue sent by a user on the list' do
+          send_message('foo XYZ-987 bar', as: @user2)
+          expect(replies.size).to eq(0)
+        end
+      end
+
+      context 'and a room list is defined' do
+        def send_room_message(body, room)
+          robot.receive(Lita::Message.new(robot, body, Lita::Source.new(user: user, room: room)))
+        end
+
+        before(:each) do
+          @room1 = 'Room1'
+          @room2 = 'Room2'
+          registry.config.handlers.jira.rooms = [@room1]
+        end
+
+        it 'shows details for a detected issue sent in a room on the list' do
+          send_room_message('foo XYZ-987 bar', @room1)
+          expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        end
+
+        it 'does not show details for a detected issue sent in a room absent from the list' do
+          send_room_message('foo XYZ-987 bar', @room2)
+          expect(replies.size).to eq(0)
+        end
+      end
+    end
+
   end
 
   describe '#myissues' do


### PR DESCRIPTION
The following features have been added:
1. Optional ambient Jira issue detection, i.e. in non-command messages
2. Prevention of duplicate responses when a Jira issue is referenced in a command, if ambient Jira issue detection is enabled
3. Optional single line responses as seen in irvingreid/lita-jira-issues/one-line-summary
4. Optional list of rooms to which responses to detected ambient Jira issues should be limited
5. Optional list of users to ignore when detecting ambient Jira issues

Features copied from https://github.com/irvingreid/lita-jira-issues/tree/one-line-summary