### PR TITLE
Require space around ambient issue matching

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --profile 5

--- a/lib/jirahelper/regex.rb
+++ b/lib/jirahelper/regex.rb
@@ -8,5 +8,6 @@ module JiraHelper
     PROJECT_PATTERN = /(?<project>[a-zA-Z0-9]{1,10})/
     ISSUE_PATTERN   = /(?<issue>#{PROJECT_PATTERN}-[0-9]{1,5}+)/
     EMAIL_PATTERN   = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
+    AMBIENT_PATTERN = /\s#{ISSUE_PATTERN}/
   end
 end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -67,7 +67,7 @@ module Lita
       )
 
       # Detect ambient JIRA issues in non-command messages
-      route ISSUE_PATTERN, :ambient, command: false
+      route AMBIENT_PATTERN, :ambient, command: false
 
       def summary(response)
         issue = fetch_issue(response.match_data['issue'])

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -180,8 +180,7 @@ describe Lita::Handlers::Jira, lita_handler: true do
   end
 
   describe '#ambient' do
-    it 'does not show details for a detected issue by default' do
-    end
+    it 'does not show details for a detected issue by default'
 
     context 'when enabled in config' do
       before(:each) do
@@ -191,11 +190,18 @@ describe Lita::Handlers::Jira, lita_handler: true do
 
       it 'shows details for a detected issue in a message' do
         send_message('foo XYZ-987 bar')
-        expect(replies.last).to eq("[XYZ-987] Some summary text\nStatus: In Progress, assigned to: A Person, fixVersion: Sprint 2, priority: P0\nhttp://jira.local/browse/XYZ-987")
+        send_message('foo XYZ-987?')
+        expect(replies.size).to eq(2)
       end
 
       it 'does not show details for a detected issue in a command' do
         send_command('foo XYZ-987 bar')
+        expect(replies.size).to eq(0)
+      end
+
+      it 'does not show details for a issue in a URL-ish context' do
+        send_message('http://www.example.com/XYZ-987.html')
+        send_message('http://www.example.com/someother-XYZ-987.html')
         expect(replies.size).to eq(0)
       end
 


### PR DESCRIPTION
For ambient issue detection, it seems like there should be a delimiter of some
sort.  Let's start out with a single prefix space, and see how it goes.  For
example, the msg "http://www.example.com/some-ISSUE-123.html" should NOT trigger
ambient issue matching, but "what about ISSUE-123?" should.

Fixes #10