### PR TITLE
Adding options to disable SSL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,10 @@ FileName:
 
 LineLength:
   Max: 190
+
+Style/IndentArray:
+  EnforcedStyle: consistent
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ config.handlers.jira.site     = 'https://your.jira.instance.example.com/'
 * `ambient` (boolean) - When set to `true`, Lita will show JIRA issue details when a JIRA issue key is mentioned in chat, outside the context of a command. Default: `false`
 * `ignore` (array) - Prevent ambient JIRA issue detection in certain users' messages. Accepts user names, mention names, and IDs. Default: `[]`
 * `rooms` (array) - Limit ambient JIRA issue detection to a certain list of rooms. If unspecified, the bot will respond to detected issues in all rooms.
+* `use_ssl` (boolean) - When set to `true`, an SSL connection will be used to JIRA. Set to `false` if you run JIRA over plain http.
 
 ``` ruby
 config.handlers.jira.context = '/myjira'
@@ -40,6 +41,7 @@ config.handlers.jira.format = 'one-line'
 config.handlers.jira.ambient = true
 config.handlers.jira.ignore = ['Jira', 'Github', 'U1234']
 config.handlers.jira.rooms = ['devtools', 'engineering']
+config.handlers.jira.use_ssl = false
 ```
 
 ## Usage

--- a/lib/jirahelper/misc.rb
+++ b/lib/jirahelper/misc.rb
@@ -9,7 +9,7 @@ module JiraHelper
         site: config.site,
         context_path: config.context,
         auth_type: :basic,
-        use_ssl: config.use_ssl,
+        use_ssl: config.use_ssl
       )
     end
   end

--- a/lib/jirahelper/misc.rb
+++ b/lib/jirahelper/misc.rb
@@ -8,7 +8,8 @@ module JiraHelper
         password: config.password,
         site: config.site,
         context_path: config.context,
-        auth_type: :basic
+        auth_type: :basic,
+        use_ssl: config.use_ssl,
       )
     end
   end

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -15,6 +15,7 @@ module Lita
       config :ambient, required: false, types: [TrueClass, FalseClass], default: false
       config :ignore, required: false, type: Array, default: []
       config :rooms, required: false, type: Array
+      config :use_ssl, required: false, types: [TrueClass, FalseClass], default: true
 
       include ::JiraHelper::Issue
       include ::JiraHelper::Misc

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -109,9 +109,9 @@ module Lita
           response.reply(t('error.request'))
           return
         end
-
+        # rubocop:disable Style/ZeroLengthPredicate
         return response.reply(t('myissues.empty')) unless issues.size > 0
-
+        # rubocop:enable Style/ZeroLengthPredicate
         response.reply(format_issues(issues))
       end
 


### PR DESCRIPTION
Some of us poor bastards are still using JIRA without SSL enabled. I modified the requests and threw an exception and it said it was an SSL error, even though my config explicitly stated `http` for the URL.

Anyway, this allows me to disable SSL, with the default being `true`

