### PR TITLE
Search multiple issue keys in single message in ambient route

### DIFF
--- a/lib/jirahelper/issue.rb
+++ b/lib/jirahelper/issue.rb
@@ -13,8 +13,11 @@ module JiraHelper
     #
     # @param [Type String] jql Valid JQL query
     # @return [Type Array] 0-m JIRA Issues returned from query
-    def fetch_issues(jql)
+    def fetch_issues(jql, suppress_exceptions = false)
       client.Issue.jql(jql)
+    rescue => e
+      throw e unless suppress_exceptions
+      nil
     end
 
     def fetch_project(key)

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -134,8 +134,15 @@ module Lita
 
       def ambient(response)
         return if invalid_ambient?(response)
-        issue = fetch_issue(response.match_data['issue'], false)
-        response.reply(format_issue(issue)) if issue
+        issue_keys = response.matches.map { |match| match[0] }
+        if issue_keys.length > 1
+          jql = "key in (#{issue_keys.join(',')})"
+          issues = fetch_issues(jql)
+          response.reply(format_issues(issues)) unless issues.empty?
+        else
+          issue = fetch_issue(response.match_data['issue'], false)
+          response.reply(format_issue(issue)) if issue
+        end
       end
 
       private

--- a/lib/lita/handlers/jira.rb
+++ b/lib/lita/handlers/jira.rb
@@ -135,8 +135,8 @@ module Lita
       def ambient(response)
         return if invalid_ambient?(response)
 
-        # response.matches returns an array of array of strings, where the inner array is [issue, project]
-        # (e.g. ["XYZ-123", "XYZ"])
+        # response.matches returns an array of array of strings, where the inner arrays are [issue, project]
+        # (e.g. [["XYZ-123", "XYZ"]]). We map it into an array of issues (["XYZ-123"]).
         issue_keys = response.matches.map { |match| match[0] }
 
         if issue_keys.length > 1

--- a/lita-jira.gemspec
+++ b/lita-jira.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-jira'
   spec.version       = '0.8.1'
-  spec.authors       = ['Eric Sigler', 'Matt Critchlow', 'Tristan Chong', 'Lee Briggs']
-  spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com', 'ong@tristaneuan.ch', 'lee@brig.gs']
+  spec.authors       = ['Eric Sigler', 'Matt Critchlow', 'Tristan Chong', 'Lee Briggs', 'Kenneth Kwan']
+  spec.email         = ['me@esigler.com', 'matt.critchlow@gmail.com', 'ong@tristaneuan.ch', 'lee@brig.gs', 'kenneth.m.kwan@gmail.com']
   spec.description   = 'A JIRA plugin for Lita.'
   spec.summary       = spec.description
   spec.homepage      = 'https://github.com/esigler/lita-jira'

--- a/spec/lita/handlers/jira_spec.rb
+++ b/spec/lita/handlers/jira_spec.rb
@@ -280,6 +280,19 @@ describe Lita::Handlers::Jira, lita_handler: true do
       expect(replies.size).to eq(0)
     end
 
+    it 'shows details for all detected issues in a message' do
+      prev_format = registry.config.handlers.jira.format
+      registry.config.handlers.jira.format = 'one-line'
+      send_message('XYZ-987 XYZ-988')
+      registry.config.handlers.jira.format = prev_format
+      expect(replies.size).to eq(3)
+      expect(replies).to eq([
+                              'Here are issues currently assigned to you:',
+                              'http://jira.local/browse/XYZ-987 - In Progress, A Person - Some summary text',
+                              'http://jira.local/browse/XYZ-988 - In Progress 2, A Person 2 - Some summary text 2'
+                            ])
+    end
+
     context 'with rooms configured' do
       def send_room_message(body, room)
         robot.receive(Lita::Message.new(robot, body, Lita::Source.new(user: user, room: room)))


### PR DESCRIPTION
Modify the `ambient` route so that it attempts to match all issue keys in the message. If there is only a single issue key found, use the pre-existing existing flow. If more than one issue key is found, build the JQL query `key in (<key1>,<key2>,...)` and perform a search in JIRA for all the issues.

Before:
![image](https://user-images.githubusercontent.com/11504503/32231987-6324452c-be2d-11e7-837e-f075dfcc531b.png)

After:
![image](https://user-images.githubusercontent.com/11504503/32232054-8584bc28-be2d-11e7-8316-24fc3532118d.png)
